### PR TITLE
feat: additional HTTP validation steps

### DIFF
--- a/steps/http/session.go
+++ b/steps/http/session.go
@@ -106,13 +106,16 @@ func (s *Session) ConfigureRequestBodyJSONProperties(ctx context.Context, props 
 			return fmt.Errorf("Error setting property '%s' with value '%s' in the request body. %s", key, value, err)
 		}
 	}
-	s.Request.RequestBody = []byte(json)
-	return nil
+	return s.ConfigureRequestBodyJSONText(ctx, json)
 }
 
-// ConfigureRequestBodyJSONText sets a json string as the HTTP request's body .
+// ConfigureRequestBodyJSONText writes the body in the HTTP request as a JSON from text.
 func (s *Session) ConfigureRequestBodyJSONText(ctx context.Context, message string) error {
 	s.Request.RequestBody = []byte(message)
+	if s.Request.Headers == nil {
+		s.Request.Headers = make(map[string][]string)
+		s.Request.Headers["Content-Type"] = append(s.Request.Headers["Content-Type"], "application/json")
+	}
 	return nil
 }
 
@@ -194,8 +197,8 @@ func (s *Session) ValidateResponseBodyEmpty(ctx context.Context) error {
 	return fmt.Errorf("The response body is not empty")
 }
 
-// StoreResponseBodyJSONPropertyValue stores in the context a key value received in the HTTP Response's body.
-func (s *Session) StoreResponseBodyJSONPropertyValue(ctx context.Context, key string, ctxtKey string) error {
+// StoreResponseBodyJSONPropertyInContext extracts a JSON property from the HTTP response body and stores it in the context.
+func (s *Session) StoreResponseBodyJSONPropertyInContext(ctx context.Context, key string, ctxtKey string) error {
 	m := golium.NewMapFromJSONBytes(s.Response.ResponseBody)
 	value := m.Get(key)
 	golium.GetContext(ctx).Put(ctxtKey, value)

--- a/steps/http/session.go
+++ b/steps/http/session.go
@@ -110,6 +110,12 @@ func (s *Session) ConfigureRequestBodyJSONProperties(ctx context.Context, props 
 	return nil
 }
 
+// ConfigureRequestBodyJSONText sets a json string as the HTTP request's body .
+func (s *Session) ConfigureRequestBodyJSONText(ctx context.Context, message string) error {
+	s.Request.RequestBody = []byte(message)
+	return nil
+}
+
 // SendHTTPRequest sends a HTTP request using the configuration in the application context.
 func (s *Session) SendHTTPRequest(ctx context.Context, method string) error {
 	logger := GetLogger()
@@ -186,4 +192,12 @@ func (s *Session) ValidateResponseBodyEmpty(ctx context.Context) error {
 		return nil
 	}
 	return fmt.Errorf("The response body is not empty")
+}
+
+// StoreResponseBodyJSONPropertyValue stores in the context a key value received in the HTTP Response's body.
+func (s *Session) StoreResponseBodyJSONPropertyValue(ctx context.Context, key string, ctxtKey string) error {
+	m := golium.NewMapFromJSONBytes(s.Response.ResponseBody)
+	value := m.Get(key)
+	golium.GetContext(ctx).Put(ctxtKey, value)
+	return nil
 }

--- a/steps/http/session.go
+++ b/steps/http/session.go
@@ -114,8 +114,8 @@ func (s *Session) ConfigureRequestBodyJSONText(ctx context.Context, message stri
 	s.Request.RequestBody = []byte(message)
 	if s.Request.Headers == nil {
 		s.Request.Headers = make(map[string][]string)
-		s.Request.Headers["Content-Type"] = append(s.Request.Headers["Content-Type"], "application/json")
 	}
+	s.Request.Headers["Content-Type"] = []string{"application/json"}
 	return nil
 }
 

--- a/steps/http/steps.go
+++ b/steps/http/steps.go
@@ -61,7 +61,7 @@ func (s Steps) InitializeSteps(ctx context.Context, scenCtx *godog.ScenarioConte
 		}
 		return session.ConfigureRequestBodyJSONProperties(ctx, props)
 	})
-	scenCtx.Step(`^the HTTP request body based in the JSON$`, func(message *godog.DocString) error {
+	scenCtx.Step(`^the HTTP request body with the JSON$`, func(message *godog.DocString) error {
 		return session.ConfigureRequestBodyJSONText(ctx, golium.ValueAsString(ctx, message.Content))
 	})
 
@@ -84,8 +84,8 @@ func (s Steps) InitializeSteps(ctx context.Context, scenCtx *godog.ScenarioConte
 	scenCtx.Step(`^the HTTP response body must be empty$`, func() error {
 		return session.ValidateResponseBodyEmpty(ctx)
 	})
-	scenCtx.Step(`^I store the field value of the json HTTP response "([^"]*)" in the context storage key "([^"]*)"$`, func(key string, ctxtKey string) error {
-		return session.StoreResponseBodyJSONPropertyValue(ctx, golium.ValueAsString(ctx, key), golium.ValueAsString(ctx, ctxtKey))
+	scenCtx.Step(`^I store the element "([^"]*)" from the JSON HTTP response body in context "([^"]*)"$`, func(key string, ctxtKey string) error {
+		return session.StoreResponseBodyJSONPropertyInContext(ctx, golium.ValueAsString(ctx, key), golium.ValueAsString(ctx, ctxtKey))
 	})
 	return ctx
 }

--- a/steps/http/steps.go
+++ b/steps/http/steps.go
@@ -61,6 +61,10 @@ func (s Steps) InitializeSteps(ctx context.Context, scenCtx *godog.ScenarioConte
 		}
 		return session.ConfigureRequestBodyJSONProperties(ctx, props)
 	})
+	scenCtx.Step(`^the HTTP request body based in the JSON$`, func(message *godog.DocString) error {
+		return session.ConfigureRequestBodyJSONText(ctx, golium.ValueAsString(ctx, message.Content))
+	})
+
 	scenCtx.Step(`^I send a HTTP "([^"]*)" request$`, func(method string) error {
 		return session.SendHTTPRequest(ctx, golium.ValueAsString(ctx, method))
 	})
@@ -79,6 +83,9 @@ func (s Steps) InitializeSteps(ctx context.Context, scenCtx *godog.ScenarioConte
 	})
 	scenCtx.Step(`^the HTTP response body must be empty$`, func() error {
 		return session.ValidateResponseBodyEmpty(ctx)
+	})
+	scenCtx.Step(`^I store the field value of the json HTTP response "([^"]*)" in the context storage key "([^"]*)"$`, func(key string, ctxtKey string) error {
+		return session.StoreResponseBodyJSONPropertyValue(ctx, golium.ValueAsString(ctx, key), golium.ValueAsString(ctx, ctxtKey))
 	})
 	return ctx
 }

--- a/test/acceptance/features/http.feature
+++ b/test/acceptance/features/http.feature
@@ -43,3 +43,29 @@ Feature: HTTP client
           | json.inactive         | [FALSE]                   |
           | json.empty            | [EMPTY]                   |
           | json.null             | [NULL]                    |
+
+  Scenario: Send a POST request defined by a json string
+    Given the HTTP endpoint "[CONF:url]/anything"
+      And the HTTP path "/test3"
+      And the HTTP request headers
+          | Authorization | Bearer access-token |
+      And the HTTP request body based in the JSON
+      """
+      {
+        "list": [
+          { "attribute": "attribute0", "value": "value0"},
+          { "attribute": "attribute1", "value": "value1"},
+          { "attribute": "attribute2", "value": "value2"}
+        ]
+      }
+      """
+     When I send a HTTP "POST" request
+     Then the HTTP status code must be "200"
+      And the HTTP response body must comply with the JSON schema "test-schema"
+      And the HTTP response body must have the JSON properties
+          | json.list.0.attribute | attribute0 |
+          | json.list.0.value     | value0     |
+          | json.list.1.attribute | attribute1 |
+          | json.list.1.value     | value1     |
+          | json.list.2.attribute | attribute2 |
+          | json.list.2.value     | value2     |

--- a/test/acceptance/features/http.feature
+++ b/test/acceptance/features/http.feature
@@ -71,7 +71,7 @@ Feature: HTTP client
           | json.list.2.value     | value2     |
       And I store the element "json.list.0.attribute" from the JSON HTTP response body in context "attr"
       And I store the element "json.list.0.value" from the JSON HTTP response body in context "val"
-    Then  the HTTP endpoint "[CONF:url]/anything"
+     Then the HTTP endpoint "[CONF:url]/anything"
       And the HTTP path "/test3-2"
       And the HTTP request headers
           | Content-Type | application/json |

--- a/test/acceptance/features/http.feature
+++ b/test/acceptance/features/http.feature
@@ -18,7 +18,7 @@ Feature: HTTP client
           | headers.Host          | [CONF:host]                                     |
           | method                | GET                                             |
           | url                   | [CONF:url]/anything/test1?exists=true&sort=name |
-
+  
   Scenario: Send a POST request
     Given the HTTP endpoint "[CONF:url]/anything"
       And the HTTP path "/test2"
@@ -44,12 +44,12 @@ Feature: HTTP client
           | json.empty            | [EMPTY]                   |
           | json.null             | [NULL]                    |
   
-  Scenario: Send a POST request defined by a json string
+  Scenario: Send a POST request defined by a json string using the context storage
     Given the HTTP endpoint "[CONF:url]/anything"
-      And the HTTP path "/test3"
+      And the HTTP path "/test3-1"
       And the HTTP request headers
-          | Authorization | Bearer access-token |
-      And the HTTP request body based in the JSON
+          | Content-Type | application/json |
+      And the HTTP request body with the JSON
       """
       {
         "list": [
@@ -60,14 +60,27 @@ Feature: HTTP client
       }
       """
      When I send a HTTP "POST" request
-     Then the HTTP status code must be "200"
+      And the HTTP status code must be "200"
       And the HTTP response body must comply with the JSON schema "test-schema"
-      And I store the field value of the json HTTP response "json.list.2.attribute" in the context storage key "key"
-      And I store the field value of the json HTTP response "json.list.2.value" in the context storage key "value"
       And the HTTP response body must have the JSON properties
-          | json.list.0.attribute | attribute0   |
-          | json.list.0.value     | value0       |
-          | json.list.1.attribute | attribute1   |
-          | json.list.1.value     | value1       |
-          | json.list.2.attribute | [CTXT:key]   |
-          | json.list.2.value     | [CTXT:value] |
+          | json.list.0.attribute | attribute0 |
+          | json.list.0.value     | value0     |
+          | json.list.1.attribute | attribute1 |
+          | json.list.1.value     | value1     |
+          | json.list.2.attribute | attribute2 |
+          | json.list.2.value     | value2     |
+      And I store the element "json.list.0.attribute" from the JSON HTTP response body in context "attr"
+      And I store the element "json.list.0.value" from the JSON HTTP response body in context "val"
+    Then  the HTTP endpoint "[CONF:url]/anything"
+      And the HTTP path "/test3-2"
+      And the HTTP request headers
+          | Content-Type | application/json |
+      And the JSON properties in the HTTP request body
+          | attribute | [CTXT:attr] |
+          | value     | [CTXT:val]  |
+      And I send a HTTP "POST" request
+      And the HTTP status code must be "200"
+      And the HTTP response body must comply with the JSON schema "test-schema"
+      And the HTTP response body must have the JSON properties
+          | json.attribute | attribute0 |
+          | json.value     | value0     |    

--- a/test/acceptance/features/http.feature
+++ b/test/acceptance/features/http.feature
@@ -43,7 +43,7 @@ Feature: HTTP client
           | json.inactive         | [FALSE]                   |
           | json.empty            | [EMPTY]                   |
           | json.null             | [NULL]                    |
-
+  
   Scenario: Send a POST request defined by a json string
     Given the HTTP endpoint "[CONF:url]/anything"
       And the HTTP path "/test3"
@@ -62,10 +62,12 @@ Feature: HTTP client
      When I send a HTTP "POST" request
      Then the HTTP status code must be "200"
       And the HTTP response body must comply with the JSON schema "test-schema"
+      And I store the field value of the json HTTP response "json.list.2.attribute" in the context storage key "key"
+      And I store the field value of the json HTTP response "json.list.2.value" in the context storage key "value"
       And the HTTP response body must have the JSON properties
-          | json.list.0.attribute | attribute0 |
-          | json.list.0.value     | value0     |
-          | json.list.1.attribute | attribute1 |
-          | json.list.1.value     | value1     |
-          | json.list.2.attribute | attribute2 |
-          | json.list.2.value     | value2     |
+          | json.list.0.attribute | attribute0   |
+          | json.list.0.value     | value0       |
+          | json.list.1.attribute | attribute1   |
+          | json.list.1.value     | value1       |
+          | json.list.2.attribute | [CTXT:key]   |
+          | json.list.2.value     | [CTXT:value] |


### PR DESCRIPTION
Implemented a couple of HTTP validation steps:

- I store the field value of the json HTTP response "yyyy" in the context storage key "xxxx"
- the HTTP request body based in the JSON