### PR TITLE
feat: check response http header

### DIFF
--- a/steps/http/session.go
+++ b/steps/http/session.go
@@ -177,14 +177,7 @@ func (s *Session) ValidateStatusCode(ctx context.Context, expectedCode int) erro
 func (s *Session) ValidateResponseHeaders(ctx context.Context, expectedHeaders map[string][]string) error {
 	for expectedHeader, expectedHeaderValues := range expectedHeaders {
 		for _, expectedHeaderValue := range expectedHeaderValues {
-			found := false
-			for _, headerValue := range s.Response.Response.Header.Values(expectedHeader) {
-				if headerValue == expectedHeaderValue {
-					found = true
-					break
-				}
-			}
-			if !found {
+			if !golium.ContainsString(expectedHeaderValue, s.Response.Response.Header.Values(expectedHeader)) {
 				return fmt.Errorf("HTTP response does not have the header '%s' with value '%s'", expectedHeader, expectedHeaderValue)
 			}
 		}

--- a/steps/http/steps.go
+++ b/steps/http/steps.go
@@ -64,12 +64,21 @@ func (s Steps) InitializeSteps(ctx context.Context, scenCtx *godog.ScenarioConte
 	scenCtx.Step(`^the HTTP request body with the JSON$`, func(message *godog.DocString) error {
 		return session.ConfigureRequestBodyJSONText(ctx, golium.ValueAsString(ctx, message.Content))
 	})
-
+	scenCtx.Step(`^the HTTP client does not follow any redirection$`, func() error {
+		return session.ConfigureNoRedirection(ctx)
+	})
 	scenCtx.Step(`^I send a HTTP "([^"]*)" request$`, func(method string) error {
 		return session.SendHTTPRequest(ctx, golium.ValueAsString(ctx, method))
 	})
 	scenCtx.Step(`^the HTTP status code must be "(\d+)"$`, func(code int) error {
 		return session.ValidateStatusCode(ctx, code)
+	})
+	scenCtx.Step(`^the HTTP response must contain the headers$`, func(t *godog.Table) error {
+		headers, err := golium.ConvertTableToMultiMap(t)
+		if err != nil {
+			return fmt.Errorf("Error processing HTTP headers from table. %s", err)
+		}
+		return session.ValidateResponseHeaders(ctx, headers)
 	})
 	scenCtx.Step(`^the HTTP response body must comply with the JSON schema "([^"]*)"$`, func(schema string) error {
 		return session.ValidateResponseBodyJSONSchema(ctx, golium.ValueAsString(ctx, schema))

--- a/test/acceptance/features/http.feature
+++ b/test/acceptance/features/http.feature
@@ -108,5 +108,5 @@ Feature: HTTP client
       And the HTTP client does not follow any redirection
      When I send a HTTP "GET" request
       And the HTTP status code must be "301"
-      And the HTTP request headers
+      And the HTTP response must contain the headers
           | Location | https://www.elevenpaths.com/ |

--- a/test/acceptance/features/http.feature
+++ b/test/acceptance/features/http.feature
@@ -11,6 +11,8 @@ Feature: HTTP client
           | Authorization | Bearer access-token |
      When I send a HTTP "GET" request
      Then the HTTP status code must be "200"
+      And the HTTP response must contain the headers
+          | Content-Type | application/json |
       And the HTTP response body must comply with the JSON schema "test-schema"
       And the HTTP response body must have the JSON properties
           | args.exists           | true                                            |
@@ -36,6 +38,8 @@ Feature: HTTP client
           | float    | [NUMBER:-34.6] |
      When I send a HTTP "POST" request
      Then the HTTP status code must be "200"
+      And the HTTP response must contain the headers
+          | Content-Type | application/json |
       And the HTTP response body must comply with the JSON schema "test-schema"
       And the HTTP response body must have the JSON properties
           | headers.Authorization | Bearer access-token       |
@@ -91,3 +95,18 @@ Feature: HTTP client
       And the HTTP response body must have the JSON properties
           | json.attribute | attribute0 |
           | json.value     | value0     |    
+
+  @http
+  Scenario: Follow redirection
+    Given the HTTP endpoint "http://www.elevenpaths.com"
+     When I send a HTTP "GET" request
+      And the HTTP status code must be "200"
+
+  @http
+  Scenario: Follow no redirection
+    Given the HTTP endpoint "http://www.elevenpaths.com"
+      And the HTTP client does not follow any redirection
+     When I send a HTTP "GET" request
+      And the HTTP status code must be "301"
+      And the HTTP request headers
+          | Location | https://www.elevenpaths.com/ |

--- a/util.go
+++ b/util.go
@@ -1,0 +1,25 @@
+// Copyright 2021 Telefonica Cybersecurity & Cloud Tech SL
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package golium
+
+// ContainsString check if a expected value is included in a slice of values.
+func ContainsString(expected string, values []string) bool {
+	for _, value := range values {
+		if expected == value {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- Step to validate a table of headers from the HTTP response.
- Step to configure HTTP not to follow redirections.