### PR TITLE
fix(http): fix empty response validation

### DIFF
--- a/steps/http/session.go
+++ b/steps/http/session.go
@@ -275,7 +275,7 @@ func (s *Session) ValidateResponseBodyJSONProperties(ctx context.Context, props 
 // ValidateResponseBodyEmpty validates that the response body is empty.
 // It checks the Content-Length header and the response body buffer.
 func (s *Session) ValidateResponseBodyEmpty(ctx context.Context) error {
-	if s.Response.Response.ContentLength == 0 && len(s.Response.ResponseBody) == 0 {
+	if s.Response.Response.ContentLength == -1 || (s.Response.Response.ContentLength == 0 && len(s.Response.ResponseBody) == 0) {
 		return nil
 	}
 	return errors.New("response body is not empty")

--- a/steps/http/session.go
+++ b/steps/http/session.go
@@ -275,7 +275,7 @@ func (s *Session) ValidateResponseBodyJSONProperties(ctx context.Context, props 
 // ValidateResponseBodyEmpty validates that the response body is empty.
 // It checks the Content-Length header and the response body buffer.
 func (s *Session) ValidateResponseBodyEmpty(ctx context.Context) error {
-	if s.Response.Response.ContentLength == -1 || (s.Response.Response.ContentLength == 0 && len(s.Response.ResponseBody) == 0) {
+	if s.Response.Response.ContentLength <= 0 && len(s.Response.ResponseBody) == 0 {
 		return nil
 	}
 	return errors.New("response body is not empty")


### PR DESCRIPTION
Fixed validation of http response as emtpy when the content length is
missing in the response and its value is -1.

> If you get -1, there is no Content-Length header in the response.
> That make sense with the HEAD verb, which does not send any content, just the headers.
> If you change the verb by GET, the content length will return the reponse length.
Source: https://stackoverflow.com/a/39732662/4110998