### PR TITLE
chore: add github community files

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW-FEATURE-REQUEST-TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/NEW-FEATURE-REQUEST-TEMPLATE.md
@@ -1,0 +1,16 @@
+Hey there and thank you for using Issue Tracker!
+
+Do the checklist before filing an issue:
+
+- [ ] Is this something you can **debug and fix**? Send a pull request! Bug fixes and documentation fixes are welcome.
+- [ ] Have a usage question? Ask your question on [StackOverflow](http://stackoverflow.com). We use StackOverflow for usage question and GitHub for bugs.
+- [ ] Find a bug? Post a bug report instead.
+
+
+None of the above, create a feature request
+------------------------------------------------------------------
+
+Make sure to add **all the information needed to understand the new feature** so that someone can help. If the info is missing we'll add the 'Needs more information' label and close the issue until there is enough information.
+
+- [ ] Provide a **minimal code snippet** / [golang playground](https://play.golang.org/) / example that reproduces the feature you request.
+- [ ] Provide **logs** or **screenshots** where appropriate

--- a/.github/ISSUE_TEMPLATE/NEW-FEATURE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/NEW-FEATURE-REQUEST.yml
@@ -1,0 +1,18 @@
+name: Feature Request
+description: File a feature request
+title: "[Feature]: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request report!
+  - type: textarea
+    id: what-is-your-suggestion
+    attributes:
+      label: What is your suggestion?
+      description: Also tell us, how do you expect to use golium?
+      placeholder: Tell us what do you want to see!
+      value: "This would be great!"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/NEW-ISSUE-TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/NEW-ISSUE-TEMPLATE.md
@@ -1,0 +1,18 @@
+Hey there and thank you for using Issue Tracker!
+
+Do the checklist before filing an issue:
+
+- [ ] Is this something you can **debug and fix**? Send a pull request! Bug fixes and documentation fixes are welcome.
+- [ ] Have a usage question? Ask your question on [StackOverflow](http://stackoverflow.com). We use StackOverflow for usage question and GitHub for bugs.
+- [ ] Have an idea for a feature? Post the feature request.
+
+
+None of the above, create a bug report
+------------------------------------------------------------------
+
+Make sure to add **all the information needed to understand the bug** so that someone can help. If the info is missing we'll add the 'Needs more information' label and close the issue until there is enough information.
+
+- [ ] Provide a **minimal code snippet** / [golang playground](https://play.golang.org/) / example that reproduces the bug.
+- [ ] Provide **logs** or **screenshots** where appropriate
+- [ ] What's the **version** of Golium you're using?
+- [ ] Are you using Mac, Linux or Windows?

--- a/.github/ISSUE_TEMPLATE/NEW-ISSUE.yml
+++ b/.github/ISSUE_TEMPLATE/NEW-ISSUE.yml
@@ -1,0 +1,34 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: [bug, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      options:
+        - 0.13.0 (latest)
+        - 0.12.5
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/PULL_REQUEST_TEMPLATE/NEW-PULL-REQUEST-TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE/NEW-PULL-REQUEST-TEMPLATE.md
@@ -1,0 +1,23 @@
+*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*
+
+Please provide enough information so that others can review your pull request:
+
+<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->
+
+Explain the **details** for making this change. What existing problem does the pull request solve?
+
+<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
+
+**Test plan (required)**
+
+Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
+
+<!-- Make sure tests pass on Github actions. -->
+
+**Code formatting**
+
+<!-- See the simple style guide. -->
+
+**Closing issues**
+
+Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,53 @@
+# Contributing to Golium
+We want to make contributing to this project as easy and transparent as possible, whether it's:
+
+- Reporting a bug
+- Discussing the current state of the code
+- Submitting a fix
+- Proposing new features
+- Becoming a maintainer
+
+## We Develop with Github
+We use github to host code, to track issues and feature requests, as well as accept pull requests.
+
+## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html), So All Code Changes Happen Through Pull Requests
+Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://guides.github.com/introduction/flow/index.html)). We actively welcome your pull requests:
+
+1. Fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. Issue that pull request!
+
+## Any contributions you make will be under the Apache Software License
+In short, when you submit code changes, your submissions are understood to be under the same [Apache License 2.0](https://choosealicense.com/licenses/apache-2.0/) that covers the project. Feel free to contact the maintainers if that's a concern.
+
+## Report bugs using Github's [issues](https://github.com/Telefonica/golium/issues)
+We use GitHub issues to track public bugs. Report a bug by [opening a new issue](); it's that easy!
+
+## Write bug reports with detail, background, and sample code
+[This is an example](http://stackoverflow.com/q/12488905/180626) of a bug report, and we think it's not a bad model. Here's [another example from Craig Hockenberry](http://www.openradar.me/11905408).
+
+**Great Bug Reports** tend to have:
+
+- A quick summary and/or background
+- Steps to reproduce
+  - Be specific!
+  - Give sample code if you can. [This stackoverflow question](http://stackoverflow.com/q/12488905/180626) includes sample code that *anyone* with a base R setup can run to reproduce what I was seeing
+- What you expected would happen
+- What actually happens
+- Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+
+## Use a Consistent Coding Style
+We follow the official guide from [Effective Go](https://golang.org/doc/effective_go).
+
+* Tabs rather than spaces for indentation
+* Document all exported package members
+* You can try running `go lint` for style unification
+
+## License
+By contributing, you agree that your contributions will be licensed under its Apache License.
+
+## References
+This document was adapted from the open-source [briandk/CONTRIBUTING.md](https://gist.github.com/briandk/3d2e8b3ec8daf5a27a62) gist.


### PR DESCRIPTION
Following [Github communities guide](https://docs.github.com/en/communities) is may be a good idea to add suggested files to golium repository to ease interactions with contributors. What do you think?