### PR TITLE
Bug #36 Add slash suffix if exists to complete path at http session

### DIFF
--- a/steps/http/session.go
+++ b/steps/http/session.go
@@ -75,7 +75,11 @@ func (s *Session) URL() (*url.URL, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid endpoint URL '%s': %w", s.Request.Endpoint, err)
 	}
-	u.Path = path.Join(u.Path, s.Request.Path)
+	u, err = u.Parse(s.Request.Path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid path URL '%s': %w", s.Request.Path, err)
+	}
+
 	params := url.Values(s.Request.QueryParams)
 	u.RawQuery = params.Encode()
 	return u, nil

--- a/steps/http/session.go
+++ b/steps/http/session.go
@@ -19,11 +19,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
 	"time"
+	"path"
 
 	"github.com/Telefonica/golium"
 	"github.com/google/uuid"
@@ -31,6 +33,10 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 )
 
+const (
+	slash string = "/"
+ )
+ 
 // Request information of the Session.
 type Request struct {
 	// Endpoint of the HTTP server. It might include a base path.
@@ -74,11 +80,10 @@ func (s *Session) URL() (*url.URL, error) {
 	if err != nil {
 		return nil, fmt.Errorf("invalid endpoint URL '%s': %w", s.Request.Endpoint, err)
 	}
-	u, err = u.Parse(s.Request.Path)
-	if err != nil {
-		return nil, fmt.Errorf("invalid path URL '%s': %w", s.Request.Path, err)
+	u.Path = path.Join(u.Path, s.Request.Path)
+	if strings.HasSuffix(s.Request.Path, slash) {
+		u.Path = u.Path + slash
 	}
-
 	params := url.Values(s.Request.QueryParams)
 	u.RawQuery = params.Encode()
 	return u, nil

--- a/steps/http/session.go
+++ b/steps/http/session.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path"
 	"time"
 
 	"github.com/Telefonica/golium"

--- a/steps/http/session.go
+++ b/steps/http/session.go
@@ -81,7 +81,12 @@ func (s *Session) URL() (*url.URL, error) {
 		return nil, fmt.Errorf("invalid endpoint URL '%s': %w", s.Request.Endpoint, err)
 	}
 	u.Path = path.Join(u.Path, s.Request.Path)
-	// NOTE: Join removes trailing slash using Clean thus, we need to add it if is s.Request.Path
+	/*
+	 * NOTE: path.Join removes trailing slash using Clean thus, 
+	 * we need to add it if is in s.Request.Path
+	 * - Reference: https://forum.golangbridge.org/t/how-to-concatenate-paths-for-api-request/5791
+	 * - Docs: https://pkg.go.dev/path#Join
+	 */
 	if strings.HasSuffix(s.Request.Path, slash) {
 		u.Path = u.Path + slash
 	}

--- a/steps/http/session.go
+++ b/steps/http/session.go
@@ -81,6 +81,7 @@ func (s *Session) URL() (*url.URL, error) {
 		return nil, fmt.Errorf("invalid endpoint URL '%s': %w", s.Request.Endpoint, err)
 	}
 	u.Path = path.Join(u.Path, s.Request.Path)
+	// NOTE: Join removes trailing slash using Clean thus, we need to add it if is s.Request.Path
 	if strings.HasSuffix(s.Request.Path, slash) {
 		u.Path = u.Path + slash
 	}

--- a/test/acceptance/features/http.feature
+++ b/test/acceptance/features/http.feature
@@ -155,3 +155,10 @@ Feature: HTTP client
       And the HTTP status code must be "200"
       And the HTTP response body must have the JSON properties
           | headers.Host | example.com |
+
+  @http
+  Scenario: Validate Not found path with trailing slash
+    Given the HTTP endpoint "[CONF:url]/image"
+      And the HTTP path "/jpeg/"
+     When I send a HTTP "POST" request
+     Then the HTTP status code must be "404"


### PR DESCRIPTION
Don't remove trailing slash when `session.URL` function is executed to be able to tests API Rest paths defined as is
fixes #36 issue