### PR TITLE
fix: rabbitmq message to check by default should be last

### DIFF
--- a/steps/rabbit/session.go
+++ b/steps/rabbit/session.go
@@ -320,10 +320,8 @@ func (s *Session) ValidateMessageTextBody(ctx context.Context, expectedMsg strin
 // ValidateMessageJSONBody checks if the message json body properties of message in position 'pos' are equal the expected values.
 // if pos == -1 then it means last message stored, that is the one stored in s.msg
 func (s *Session) ValidateMessageJSONBody(ctx context.Context, props map[string]interface{}, pos int) error {
-	logrus.Debugf("pos: %d", pos)
 	m := golium.NewMapFromJSONBytes([]byte(s.msg.Body))
 	if pos != -1 {
-		logrus.Debugf("inside wrong")
 		nMessages := len(s.Messages)
 		if pos < 0 || pos >= nMessages {
 			return fmt.Errorf("trying to validate message in position: '%d', '%d' messages available", pos, nMessages)

--- a/steps/rabbit/session.go
+++ b/steps/rabbit/session.go
@@ -318,12 +318,18 @@ func (s *Session) ValidateMessageTextBody(ctx context.Context, expectedMsg strin
 }
 
 // ValidateMessageJSONBody checks if the message json body properties of message in position 'pos' are equal the expected values.
+// if pos == -1 then it means last message stored, that is the one stored in s.msg
 func (s *Session) ValidateMessageJSONBody(ctx context.Context, props map[string]interface{}, pos int) error {
-	nMessages := len(s.Messages)
-	if pos < 0 || pos >= nMessages {
-		return fmt.Errorf("trying to validate message in position: '%d', '%d' messages available", pos, nMessages)
+	logrus.Debugf("pos: %d", pos)
+	m := golium.NewMapFromJSONBytes([]byte(s.msg.Body))
+	if pos != -1 {
+		logrus.Debugf("inside wrong")
+		nMessages := len(s.Messages)
+		if pos < 0 || pos >= nMessages {
+			return fmt.Errorf("trying to validate message in position: '%d', '%d' messages available", pos, nMessages)
+		}
+		m = golium.NewMapFromJSONBytes([]byte(s.Messages[pos].Body))
 	}
-	m := golium.NewMapFromJSONBytes([]byte(s.Messages[pos].Body))
 	for key, expectedValue := range props {
 		value := m.Get(key)
 		if value != expectedValue {

--- a/steps/rabbit/steps.go
+++ b/steps/rabbit/steps.go
@@ -137,7 +137,7 @@ func (cs Steps) InitializeSteps(ctx context.Context, scenCtx *godog.ScenarioCont
 		if err != nil {
 			return fmt.Errorf("failed processing table to a map for the rabbit message: %w", err)
 		}
-		return session.ValidateMessageJSONBody(ctx, props, 0)
+		return session.ValidateMessageJSONBody(ctx, props, -1)
 	})
 	scenCtx.Step(`^the body of the rabbit message in position "(\d+)" has the JSON properties$`, func(pos int, t *godog.Table) error {
 		props, err := golium.ConvertTableToMap(ctx, t)


### PR DESCRIPTION
The last modification allowed to check an specific message in those received.

To adapt old step where only one was checked, it was decided to check that in possition 0, but that's wrong as it should be the one stored in session.message member (as was before).