### PR TITLE
fix: content-type header in mock response

### DIFF
--- a/mock/http/server.go
+++ b/mock/http/server.go
@@ -84,12 +84,12 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	w.WriteHeader(resp.Status)
 	for header, values := range resp.Headers {
 		for _, value := range values {
 			w.Header().Add(header, value)
 		}
 	}
+	w.WriteHeader(resp.Status)
 	if _, err := w.Write([]byte(resp.Body)); err != nil {
 		s.logger.Errorf("Failed writing the response body: %s", err)
 	}

--- a/test/acceptance/features/mockhttp.feature
+++ b/test/acceptance/features/mockhttp.feature
@@ -12,7 +12,7 @@ Feature: HTTP Mock server
     Given the HTTP endpoint "[CONF:httpMockUrl]/test/[CTXT:id]"
      When I send a HTTP "GET" request
      Then the HTTP status code must be "200"
-      And the HTTP request headers
+      And the HTTP response must contain the headers
           | Content-Type | application/json |
       And the HTTP response body must have the JSON properties
           | value | test mock response |
@@ -88,7 +88,7 @@ Feature: HTTP Mock server
     Given the HTTP endpoint "[CONF:httpMockUrl]/test/[CTXT:id]"
      When I send a HTTP "POST" request
      Then the HTTP status code must be "201"
-      And the HTTP request headers
+      And the HTTP response must contain the headers
           | Content-Type | application/json |
       And the HTTP response body must have the JSON properties
           | value | test mock response |
@@ -115,7 +115,7 @@ Feature: HTTP Mock server
     Given the HTTP endpoint "[CONF:httpMockUrl]/test/[CTXT:id]"
      When I send a HTTP "POST" request
      Then the HTTP status code must be "201"
-      And the HTTP request headers
+      And the HTTP response must contain the headers
           | Content-Type | application/json |
       And the HTTP response body must have the JSON properties
           | values.0.path | /[CTXT:id]-[CTXT:id] |
@@ -166,7 +166,7 @@ Feature: HTTP Mock server
     Given the HTTP endpoint "[CONF:httpMockUrl]/test/text-plain/[CTXT:id]"
      When I send a HTTP "GET" request
      Then the HTTP status code must be "200"
-      And the HTTP request headers
+      And the HTTP response must contain the headers
           | Content-Type | text/plain |
       And the HTTP response body must be the text
           """


### PR DESCRIPTION
Fix for the HTTP mock server to send the HTTP headers in the responses generated by the mock server.
Also fix the feature file for httpmock that did not check the Content-Type HTTP response header.