### PR TITLE
fix: [S3] Allow to use AWS REGION env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: minioadmin
       AWS_REGION: eu-west-1
 
-
     services:
       redis:
         image: redis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_REGION: eu-west-1
+
+
     services:
       redis:
         image: redis

--- a/test/acceptance/environments/local.yml
+++ b/test/acceptance/environments/local.yml
@@ -104,14 +104,11 @@ elasticsearch:
 
 # s3
 s3Autoclean: true
-s3Region: eu-west-1
 s3Bucket: golium-demo
+# Set minio to true to run test against minio server deployed locally otherwise set it to false or remove it
 minio: true
-# Below config is only required by minio server
-# To grant access to AWS set minio parameter to false and configure the env vars: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
 minioEndpoint: http://localhost:9999
-minioAwsAccessKeyId: minioadmin
-minioAwsSecretAccessKey: minioadmin
+# Use AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION env vars to define aws or minio credentials
 
 # common
 defaultDelay: 1


### PR DESCRIPTION
aws S3 client library uses these mandatory env var to grant the access: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION

As the current golium implementation does not take AWS_REGION in consideration, we'd enable it.  

AWS_REGION could be overwritten by s3Region config parameter, still needed to test against minio server